### PR TITLE
Reduce the time for Grid Search

### DIFF
--- a/src/modelfactory.py
+++ b/src/modelfactory.py
@@ -8,7 +8,7 @@ import os.path as path
 
 
 # Create base class in order to provide proper callbacks to the model
-def build_autoencoder(verbose=1):
+def build_autoencoder(verbose=0):
     """
     Builds and autoencoder model that can be used by scikit_learn API.
 

--- a/src/train-encoder.py
+++ b/src/train-encoder.py
@@ -57,16 +57,11 @@ def run(args):
         'epochs': [args.num_epochs],
         'sample_dim': [ds.sample_size],
         'batch_size': [1, 16, 64],
-        'optimizer': ['adam', 'adagrad', 'nadam', 'adamax'],
+        'optimizer': ['adam'],
         'encoding_dim': [16, 32, 64, 128],
-        'encoder_activation':
-        ['sigmoid', 'elu', 'softmax', 'relu', 'tanh', 'linear'],
-        'decoder_activation':
-        ['sigmoid', 'elu', 'softmax', 'relu', 'tanh', 'linear'],
-        'loss': [
-            'mean_squared_error', 'cosine_proximity',
-            'kullback_leibler_divergence'
-        ]
+        'encoder_activation': ['relu'],
+        'decoder_activation': ['linear'],
+        'loss': ['cosine_proximity']
     }
 
     gs = GridSearchCV(estimator=model,


### PR DESCRIPTION
----

## The previous configuration for GridSearchCV was too exhaustive

Previous configuration for GridSearchCV takes several day to run due to too much combinations of parameters that need a new training.

Another issue with the training is that the default verbosity level of the `Keras` model is set to `1` which is quite unreadable when training with multiple jobs.

The current changes restrict the grid search to only the number of dimensions of internal representation and set `Keras` models to silent.